### PR TITLE
Fix broken essential websites for biologists link

### DIFF
--- a/README.md
+++ b/README.md
@@ -248,7 +248,7 @@ Laboratory Manuals
 Blogs/Links
 ----------------
 
-* [What are some essential websites for biologists?](https://www.ocf.berkeley.edu/~asiegel/posts/?p=35)
+* [What are some essential websites for biologists?](https://www.quora.com/What-are-some-essential-websites-for-biologists/answer/Alex-Siegel?srid=Tds3)
 * [**Talks at ICTS**](https://www.youtube.com/user/ICTStalks/playlists), an
 interesting collection of talks on statistical physics, systems biology, and
 much more.


### PR DESCRIPTION
Current link is broken. Looking at the original site (which can be found in an archive https://web.archive.org/web/20140514185352/http://www.ocf.berkeley.edu:80/~asiegel/posts/?p=35), it is similar to a live link, which I've added as the Quora page.